### PR TITLE
Switch to use API upload from CS pipelines by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,11 +11,13 @@ from pathlib import Path
 from warnings import warn
 import pytest
 import requests
+import typing as ty
 import numpy
 import docker
 import random
 import nibabel
-from click.testing import CliRunner
+import docker.models.containers
+from click.testing import CliRunner, Result as CliResult
 from imageio.core.fetching import get_remote_file
 import xnat4tests
 import medimages4tests.dummy.nifti
@@ -42,11 +44,12 @@ from frametree.xnat.cs import XnatViaCS
 if os.getenv("_PYTEST_RAISE", "0") != "0":
 
     @pytest.hookimpl(tryfirst=True)
-    def pytest_exception_interact(call):
-        raise call.excinfo.value
+    def pytest_exception_interact(call: pytest.CallInfo[ty.Any]) -> None:
+        if call.excinfo is not None:
+            raise call.excinfo.value
 
     @pytest.hookimpl(tryfirst=True)
-    def pytest_internalerror(excinfo):
+    def pytest_internalerror(excinfo: pytest.ExceptionInfo[BaseException]) -> None:
         raise excinfo.value
 
     CATCH_CLI_EXCEPTIONS = False
@@ -55,7 +58,7 @@ else:
 
 
 @pytest.fixture
-def catch_cli_exceptions():
+def catch_cli_exceptions() -> bool:
     return CATCH_CLI_EXCEPTIONS
 
 
@@ -84,16 +87,18 @@ logger.addHandler(sch)
 
 
 @pytest.fixture(scope="session")
-def run_prefix():
+def run_prefix() -> str:
     "A datetime string used to avoid stale data left over from previous tests"
     return datetime.strftime(datetime.now(), "%Y%m%d%H%M%S")
 
 
 @pytest.fixture
-def cli_runner(catch_cli_exceptions):
-    def invoke(*args, catch_exceptions=catch_cli_exceptions, **kwargs):
+def cli_runner(catch_cli_exceptions: bool) -> ty.Callable[..., ty.Any]:
+    def invoke(
+        *args: ty.Any, catch_exceptions: bool = catch_cli_exceptions, **kwargs: ty.Any
+    ) -> CliResult:
         runner = CliRunner()
-        result = runner.invoke(*args, catch_exceptions=catch_exceptions, **kwargs)
+        result = runner.invoke(*args, catch_exceptions=catch_exceptions, **kwargs)  # type: ignore[misc]
         return result
 
     return invoke
@@ -106,17 +111,17 @@ def work_dir() -> Path:
 
 
 @pytest.fixture(scope="session")
-def build_cache_dir():
+def build_cache_dir() -> Path:
     return Path(mkdtemp())
 
 
 @pytest.fixture(scope="session")
-def pkg_dir():
+def pkg_dir() -> Path:
     return PKG_DIR
 
 
 @pytest.fixture(scope="session")
-def frametree_home() -> Path:
+def frametree_home() -> ty.Generator[Path, None, None]:
     frametree_home = Path(tempfile.mkdtemp()) / "frametree-home"
     with patch.dict(os.environ, {"FRAMETREE_HOME": str(frametree_home)}):
         yield frametree_home
@@ -292,7 +297,7 @@ TEST_XNAT_DATASET_BLUEPRINTS = {
         ],
         derivatives=[
             FileBP(
-                path="concatenated",
+                path="concatenated_file",
                 row_frequency=Clinical.session,
                 datatype=Text,
                 filenames=["concatenated.txt"],
@@ -315,8 +320,8 @@ def static_dataset(
     xnat_archive_dir: Path,
     source_data: Path,
     run_prefix: str,
-    request,
-):
+    request: pytest.FixtureRequest,
+) -> FrameSet:
     """Creates a static dataset to can be reused between unittests and save setup
     times"""
     dataset_id, access_method = request.param.split(".")
@@ -341,8 +346,8 @@ def dataset(
     xnat_archive_dir: Path,
     source_data: Path,
     run_prefix: str,
-    request,
-):
+    request: pytest.FixtureRequest,
+) -> FrameSet:
     """Creates a dataset that can be mutated (as its name is unique to the function)"""
     dataset_id, access_method = request.param.split(".")
     blueprint = TEST_XNAT_DATASET_BLUEPRINTS[dataset_id]
@@ -365,7 +370,7 @@ def dataset(
 
 
 @pytest.fixture
-def simple_dataset(xnat_repository, work_dir, run_prefix):
+def simple_dataset(xnat_repository: Xnat, work_dir: Path, run_prefix: str) -> FrameSet:
     blueprint = TestXnatDatasetBlueprint(
         dim_lengths=[1, 1, 1],
         scans=[
@@ -386,7 +391,7 @@ def access_dataset(
     xnat_archive_dir: Path,
     run_prefix: str,
 ) -> FrameSet:
-    if access_method == "cs":
+    if access_method.startswith("cs"):
         proj_dir = xnat_archive_dir / project_id / "arc001"
         store = XnatViaCS(
             server=xnat_repository.server,
@@ -396,6 +401,7 @@ def access_dataset(
             row_frequency=Clinical.constant,
             input_mount=proj_dir,
             output_mount=Path(mkdtemp()),
+            internal_upload=access_method.endswith("internal"),
         )
         store.save(name=f"testxnatcs{run_prefix}")
     elif access_method == "api":
@@ -412,17 +418,19 @@ def xnat4tests_config() -> xnat4tests.Config:
 
 
 @pytest.fixture(scope="session")
-def xnat_root_dir(xnat4tests_config) -> Path:
-    return xnat4tests_config.xnat_root_dir
+def xnat_root_dir(xnat4tests_config: xnat4tests.Config) -> Path:
+    return xnat4tests_config.xnat_root_dir  # type: ignore[no-any-return]
 
 
 @pytest.fixture(scope="session")
-def xnat_archive_dir(xnat_root_dir):
+def xnat_archive_dir(xnat_root_dir: Path) -> Path:
     return xnat_root_dir / "archive"
 
 
 @pytest.fixture(scope="session")
-def xnat_repository(run_prefix, xnat4tests_config, frametree_home):
+def xnat_repository(
+    run_prefix: str, xnat4tests_config: xnat4tests.Config, frametree_home: Path
+) -> Xnat:
 
     xnat4tests.start_xnat()
 
@@ -442,7 +450,9 @@ def xnat_repository(run_prefix, xnat4tests_config, frametree_home):
 
 
 @pytest.fixture(scope="session")
-def xnat_via_cs_repository(run_prefix, xnat4tests_config, frametree_home):
+def xnat_via_cs_repository(
+    run_prefix: str, xnat4tests_config: xnat4tests.Config, frametree_home: Path
+) -> XnatViaCS:
 
     xnat4tests.start_xnat()
 
@@ -462,17 +472,19 @@ def xnat_via_cs_repository(run_prefix, xnat4tests_config, frametree_home):
 
 
 @pytest.fixture(scope="session")
-def xnat_respository_uri(xnat_repository):
-    return xnat_repository.server
+def xnat_respository_uri(xnat_repository: Xnat) -> str:
+    return xnat_repository.server  # type: ignore[no-any-return]
 
 
 @pytest.fixture(scope="session")
-def docker_registry_for_xnat():
+def docker_registry_for_xnat() -> docker.models.containers.Container:
     return xnat4tests.start_registry()
 
 
 @pytest.fixture(scope="session")
-def docker_registry_for_xnat_uri(docker_registry_for_xnat):
+def docker_registry_for_xnat_uri(
+    docker_registry_for_xnat: docker.models.containers.Container,
+) -> str:
     if sys.platform == "linux":
         uri = "172.17.0.1"  # Linux + GH Actions
     else:
@@ -481,21 +493,23 @@ def docker_registry_for_xnat_uri(docker_registry_for_xnat):
 
 
 @pytest.fixture
-def dummy_niftix(work_dir):
+def dummy_niftix(work_dir: Path) -> NiftiX:
 
     nifti_path = work_dir / "t1w.nii"
     json_path = work_dir / "t1w.json"
 
     # Create a random Nifti file to satisfy BIDS parsers
-    hdr = nibabel.Nifti1Header()
-    hdr.set_data_shape((10, 10, 10))
-    hdr.set_zooms((1.0, 1.0, 1.0))  # set voxel size
-    hdr.set_xyzt_units(2)  # millimeters
-    hdr.set_qform(numpy.diag([1, 2, 3, 1]))
-    nibabel.save(
-        nibabel.Nifti1Image(
-            numpy.random.randint(0, 1, size=[10, 10, 10]),
-            hdr.get_best_affine(),
+    hdr = nibabel.Nifti1Header()  # type: ignore[attr-defined,no-untyped-call]
+    hdr.set_data_shape((10, 10, 10))  # type: ignore[no-untyped-call]
+    # set voxel size
+    hdr.set_zooms((1.0, 1.0, 1.0))  # type: ignore[no-untyped-call]
+    # millimeters
+    hdr.set_xyzt_units(2)  # type: ignore[no-untyped-call]
+    hdr.set_qform(numpy.diag([1, 2, 3, 1]))  # type: ignore[no-untyped-call]
+    nibabel.save(  # type: ignore[attr-defined, no-untyped-call]
+        nibabel.Nifti1Image(  # type: ignore[attr-defined, no-untyped-call]
+            numpy.random.randint(0, 1, size=[10, 10, 10]),  # type: ignore[attr-defined,no-untyped-call]
+            hdr.get_best_affine(),  # type: ignore[attr-defined, no-untyped-call]
             header=hdr,
         ),
         nifti_path,
@@ -504,11 +518,11 @@ def dummy_niftix(work_dir):
     with open(json_path, "w") as f:
         json.dump({"test": "json-file"}, f)
 
-    return NiftiX.from_fspaths(nifti_path, json_path)
+    return NiftiX.from_fspaths(nifti_path, json_path)  # type: ignore[attr-defined, no-any-return]
 
 
 @pytest.fixture(scope="session")
-def command_spec():
+def command_spec() -> ty.Dict[str, ty.Any]:
     return {
         "task": "frametree.testing.tasks:concatenate",
         "inputs": {
@@ -556,7 +570,7 @@ BIDS_VALIDATOR_APP_IMAGE = "pipeline2app-bids-validator-app"
 
 
 @pytest.fixture(scope="session")
-def bids_command_spec(mock_bids_app_executable):
+def bids_command_spec(mock_bids_app_executable: str) -> ty.Dict[str, ty.Any]:
     inputs = {
         "T1w": {
             "configuration": {
@@ -612,12 +626,12 @@ def bids_command_spec(mock_bids_app_executable):
 
 
 @pytest.fixture(scope="session")
-def bids_success_str():
+def bids_success_str() -> str:
     return SUCCESS_STR
 
 
 @pytest.fixture(scope="session")
-def bids_validator_app_script():
+def bids_validator_app_script() -> str:
     return f"""#!/bin/sh
 # Echo inputs to get rid of any quotes
 BIDS_DATASET=$(echo $1)
@@ -639,7 +653,7 @@ echo 'file2' > $OUTPUTS_DIR/sub-${{SUBJ_ID}}_file2.txt
 
 # FIXME: should be converted to python script to be Windows compatible
 @pytest.fixture(scope="session")
-def mock_bids_app_script():
+def mock_bids_app_script() -> str:
     file_tests = ""
     for inpt_path, datatype in [
         ("anat/T1w", NiftiGzX),
@@ -667,7 +681,7 @@ echo 'file2' > $OUTPUTS_DIR/sub-${{SUBJ_ID}}_file2.txt
 
 
 @pytest.fixture(scope="session")
-def mock_bids_app_executable(build_cache_dir, mock_bids_app_script):
+def mock_bids_app_executable(build_cache_dir: Path, mock_bids_app_script: str) -> Path:
     # Create executable that runs validator then produces some mock output
     # files
     script_path = build_cache_dir / "mock-bids-app-executable.sh"
@@ -678,7 +692,7 @@ def mock_bids_app_executable(build_cache_dir, mock_bids_app_script):
 
 
 @pytest.fixture(scope="session")
-def mock_bids_app_image(mock_bids_app_script, build_cache_dir):
+def mock_bids_app_image(mock_bids_app_script: str, build_cache_dir: Path) -> str:
     return build_app_image(
         MOCK_BIDS_APP_IMAGE,
         mock_bids_app_script,
@@ -688,7 +702,7 @@ def mock_bids_app_image(mock_bids_app_script, build_cache_dir):
 
 
 @pytest.fixture(scope="session")
-def bids_validator_docker():
+def bids_validator_docker() -> str:
     dc = docker.from_env()
     try:
         dc.images.pull(BIDS_VALIDATOR_DOCKER)
@@ -697,7 +711,9 @@ def bids_validator_docker():
     return BIDS_VALIDATOR_DOCKER
 
 
-def build_app_image(tag_name, script, build_cache_dir, base_image):
+def build_app_image(
+    tag_name: str, script: str, build_cache_dir: Path, base_image: str
+) -> str:
     dc = docker.from_env()
 
     # Create executable that runs validator then produces some mock output
@@ -723,7 +739,7 @@ ENTRYPOINT ["/launch.sh"]"""
 
 
 @pytest.fixture(scope="session")
-def source_data():
+def source_data() -> Path:
     source_data = Path(tempfile.mkdtemp())
     # Create NIFTI data
     nifti_dir = source_data / "nifti"
@@ -737,6 +753,10 @@ def source_data():
             with open(fpath, "w") as f:
                 json.dump(fdata, f)
         else:
+            if not isinstance(fdata, str):
+                raise ValueError(
+                    f"Only string data can be written to text files, not: {fdata}"
+                )
             with open(fpath, "w") as f:
                 f.write(fdata)
     # Create DICOM data
@@ -746,12 +766,12 @@ def source_data():
         out_dir=dicom_dir / "fmap"
     )
     # Create png data
-    get_remote_file("images/chelsea.png", directory=source_data)
+    get_remote_file("images/chelsea.png", directory=source_data)  # type: ignore[no-untyped-call]
     return source_data
 
 
 @pytest.fixture(scope="session")
-def nifti_sample_dir(source_data):
+def nifti_sample_dir(source_data: Path) -> Path:
     return source_data / "nifti"
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -300,7 +300,7 @@ TEST_XNAT_DATASET_BLUEPRINTS = {
                 path="concatenated_file",
                 row_frequency=Clinical.session,
                 datatype=Text,
-                filenames=["concatenated.txt"],
+                filenames=["concatenated_file_sink.txt"],
             )
         ],
     ),

--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ PKG_DIR = Path(__file__).parent
 
 log_level = logging.WARNING
 
-logger = logging.getLogger("arcana")
+logger = logging.getLogger("pipeline2app")
 logger.setLevel(log_level)
 
 sch = logging.StreamHandler()
@@ -73,7 +73,7 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 sch.setFormatter(formatter)
 logger.addHandler(sch)
 
-logger = logging.getLogger("arcana")
+logger = logging.getLogger("pipeline2app")
 logger.setLevel(log_level)
 
 sch = logging.StreamHandler()
@@ -116,10 +116,10 @@ def pkg_dir():
 
 
 @pytest.fixture
-def arcana_home(work_dir):
-    arcana_home = work_dir / "arcana-home"
-    with patch.dict(os.environ, {"PYDRA2APP_HOME": str(arcana_home)}):
-        yield arcana_home
+def pipeline2app_home(work_dir):
+    pipeline2app_home = work_dir / "pipeline2app-home"
+    with patch.dict(os.environ, {"PIPELINE2APP_HOME": str(pipeline2app_home)}):
+        yield pipeline2app_home
 
 
 # -----------------------
@@ -541,8 +541,8 @@ def command_spec():
 
 BIDS_VALIDATOR_DOCKER = "bids/validator:latest"
 SUCCESS_STR = "This dataset appears to be BIDS compatible"
-MOCK_BIDS_APP_IMAGE = "arcana-mock-bids-app"
-BIDS_VALIDATOR_APP_IMAGE = "arcana-bids-validator-app"
+MOCK_BIDS_APP_IMAGE = "pipeline2app-mock-bids-app"
+BIDS_VALIDATOR_APP_IMAGE = "pipeline2app-bids-validator-app"
 
 
 @pytest.fixture(scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -392,7 +392,7 @@ def access_dataset(
     run_prefix: str,
 ) -> FrameSet:
     if access_method.startswith("cs"):
-        proj_dir = xnat_archive_dir / project_id / "arc001"
+        proj_dir = xnat_archive_dir / project_id
         store = XnatViaCS(
             server=xnat_repository.server,
             user=xnat_repository.user,

--- a/conftest.py
+++ b/conftest.py
@@ -116,7 +116,7 @@ def pkg_dir():
 
 
 @pytest.fixture(scope="session")
-def frametree_home():
+def frametree_home() -> Path:
     frametree_home = Path(tempfile.mkdtemp()) / "frametree-home"
     with patch.dict(os.environ, {"FRAMETREE_HOME": str(frametree_home)}):
         yield frametree_home
@@ -330,7 +330,9 @@ def static_dataset(
         name="",
     )
     logger.debug("accessing dataset at %s", project_id)
-    return access_dataset(project_id, access_method, xnat_repository, xnat_archive_dir)
+    return access_dataset(
+        project_id, access_method, xnat_repository, xnat_archive_dir, run_prefix
+    )
 
 
 @pytest.fixture(params=MUTABLE_DATASETS, scope="function")

--- a/pipeline2app/xnat/__init__.py
+++ b/pipeline2app/xnat/__init__.py
@@ -1,2 +1,4 @@
 from .image import XnatApp
 from .command import XnatCommand
+
+__all__ = ["XnatApp", "XnatCommand"]

--- a/pipeline2app/xnat/cli/entrypoint.py
+++ b/pipeline2app/xnat/cli/entrypoint.py
@@ -24,6 +24,15 @@ in the format <store-nickname>//<dataset-id>[@<dataset-name>]
 @entrypoint_opts.execution  # type: ignore[misc]
 @entrypoint_opts.debugging  # type: ignore[misc]
 @entrypoint_opts.dataset_config  # type: ignore[misc]
+@click.option(
+    "--internal-upload/--external-upload",
+    type=bool,
+    default=False,
+    help=(
+        "Whether to upload the output to the XNAT using the container service's "
+        "internal upload mechanism instead of the XNAT REST API"
+    ),
+)
 def cs_entrypoint(
     address: str,
     spec_path: Path,

--- a/pipeline2app/xnat/cli/entrypoint.py
+++ b/pipeline2app/xnat/cli/entrypoint.py
@@ -1,4 +1,6 @@
 import click
+from pathlib import Path
+import typing as ty
 from pipeline2app.core.command import entrypoint_opts
 from pipeline2app.xnat import XnatApp
 from .base import xnat_group
@@ -15,18 +17,18 @@ dataset (e.g. XNAT project ID or file-system directory) and the dataset's name
 in the format <store-nickname>//<dataset-id>[@<dataset-name>]
 
 """,
-)
+)  # type: ignore[misc]
 @click.argument("address")
-@entrypoint_opts.data_columns
-@entrypoint_opts.parameterisation
-@entrypoint_opts.execution
-@entrypoint_opts.debugging
-@entrypoint_opts.dataset_config
+@entrypoint_opts.data_columns  # type: ignore[misc]
+@entrypoint_opts.parameterisation  # type: ignore[misc]
+@entrypoint_opts.execution  # type: ignore[misc]
+@entrypoint_opts.debugging  # type: ignore[misc]
+@entrypoint_opts.dataset_config  # type: ignore[misc]
 def cs_entrypoint(
-    address,
-    spec_path,
-    **kwargs,
-):
+    address: str,
+    spec_path: Path,
+    **kwargs: ty.Any,
+) -> None:
 
     image_spec = XnatApp.load(spec_path)
 

--- a/pipeline2app/xnat/cli/release.py
+++ b/pipeline2app/xnat/cli/release.py
@@ -45,7 +45,7 @@ def load_auth(server, user, password, auth_file):
     name="install-command",
     help="""Installs a container service pipelines command on an XNAT server
 
-IMAGE_OR_COMMAND_FILE the name of the Pydra2App container service pipeline Docker image or
+IMAGE_OR_COMMAND_FILE the name of the Pipeline2app container service pipeline Docker image or
 the path to a command JSON file to install
 """,
 )
@@ -298,7 +298,7 @@ Which of available pipelines to install can be controlled by a YAML file passed 
     - tag: ghcr.io/Australian-Imaging-Service/pet.rodent.*
     exclude:
     - tag: ghcr.io/Australian-Imaging-Service/mri.human.neuro.bidsapps.
-""",
+""",  # noqa
 )
 @click.argument("manifest_file", type=click.File())
 @click.option(
@@ -369,7 +369,7 @@ def deploy_pipelines(manifest_file, server, user, password, auth_file, filters_f
             if matches_entry(entry, filters.get("include")) and not matches_entry(
                 entry, filters.get("exclude"), default=False
             ):
-                tag = f"{entry['name']}:{entry['version']}"
+                tag = f"{entry['name']}:{entry['version']}"  # noqa
                 xlogin.post(
                     "/xapi/docker/pull", query={"image": tag, "save-commands": True}
                 )

--- a/pipeline2app/xnat/command.py
+++ b/pipeline2app/xnat/command.py
@@ -208,10 +208,10 @@ class XnatCommand(ContainerCommand):
     def add_pipeline2app_flags_field(self, cmd_json):
 
         # Add input for dataset name
-        FLAGS_KEY = "#PYDRA2APP_FLAGS#"
+        FLAGS_KEY = "#PIPELINE2APP_FLAGS#"
         cmd_json["inputs"].append(
             {
-                "name": "Pydra2App_flags",
+                "name": "Pipeline2app_flags",
                 "description": "Flags passed to `run-pipeline2app-pipeline` command",
                 "type": "string",
                 "default-value": (

--- a/pipeline2app/xnat/command.py
+++ b/pipeline2app/xnat/command.py
@@ -226,6 +226,9 @@ class XnatCommand(ContainerCommand):  # type: ignore[misc]
                 )
                 cmd_args.append(f"--output {output.name} '{replacement_key}'")
 
+        if self.internal_upload:
+            cmd_args.append("--internal-upload")
+
         return cmd_args
 
     def add_pipeline2app_flags_field(self, cmd_json: ty.Dict[str, ty.Any]) -> str:

--- a/pipeline2app/xnat/command.py
+++ b/pipeline2app/xnat/command.py
@@ -5,7 +5,8 @@ import attrs
 from fileformats.core import FileSet, to_mime
 from pipeline2app.core.command.base import ContainerCommand
 from frametree.xnat import XnatViaCS
-from frametree.xnat.api import path2label
+from frametree.core.axes import Axes
+from frametree.core.utils import path2label
 from frametree.common import Clinical
 
 
@@ -13,15 +14,16 @@ if ty.TYPE_CHECKING:
     from .image import XnatApp
 
 
-@attrs.define(kw_only=True)
-class XnatCommand(ContainerCommand):
+@attrs.define(kw_only=True, auto_attribs=False)
+class XnatCommand(ContainerCommand):  # type: ignore[misc]
 
-    image: ty.Optional[XnatApp] = None
+    image: ty.Optional[XnatApp] = attrs.field(default=None)
+    internal_upload: bool = attrs.field(default=False)
 
     # Hard-code the axes of XNAT commands to be clinical
-    AXES = Clinical
+    AXES: ty.Optional[ty.Type[Axes]] = Clinical
 
-    def make_json(self):
+    def make_json(self) -> ty.Dict[str, ty.Any]:
         """Constructs the XNAT CS "command" JSON config, which specifies how XNAT
         should handle the containerised pipeline
 
@@ -57,7 +59,7 @@ class XnatCommand(ContainerCommand):
 
         return cmd_json
 
-    def init_command_json(self):
+    def init_command_json(self) -> ty.Dict[str, ty.Any]:
         """Initialises the command JSON that specifies to the XNAT Cs how the command
         should be run
 
@@ -103,7 +105,7 @@ class XnatCommand(ContainerCommand):
 
         return cmd_json
 
-    def add_input_fields(self, cmd_json):
+    def add_input_fields(self, cmd_json: ty.Dict[str, ty.Any]) -> ty.List[str]:
         """Adds pipeline inputs to the command JSON
 
         Parameters
@@ -146,7 +148,7 @@ class XnatCommand(ContainerCommand):
 
         return cmd_args
 
-    def add_parameter_fields(self, cmd_json):
+    def add_parameter_fields(self, cmd_json: ty.Dict[str, ty.Any]) -> ty.List[str]:
 
         # Add parameters as additional inputs to inputs JSON specification
         cmd_args = []
@@ -170,7 +172,7 @@ class XnatCommand(ContainerCommand):
 
         return cmd_args
 
-    def add_output_fields(self, cmd_json):
+    def add_output_fields(self, cmd_json: ty.Dict[str, ty.Any]) -> ty.List[str]:
 
         # Set up output handlers and arguments
         cmd_args = []
@@ -178,36 +180,55 @@ class XnatCommand(ContainerCommand):
             out_fname = output.name + (
                 output.datatype.ext if output.datatype.ext else ""
             )
+
+            desc = (
+                f"Output ({to_mime(output.datatype, official=False)}): " + output.help
+            )
             # Set the path to the
-            cmd_json["outputs"].append(
-                {
-                    "name": output.name,
-                    "description": f"{output.field} ({to_mime(output.datatype)})",
-                    "required": True,
-                    "mount": "out",
-                    "path": out_fname,
-                    "glob": None,
-                }
-            )
-            cmd_json["xnat"][0]["output-handlers"].append(
-                {
-                    "name": f"{output.name}-resource",
-                    "accepts-command-output": output.name,
-                    "via-wrapup-command": None,
-                    "as-a-child-of": "SESSION",
-                    "type": "Resource",
-                    # Shame that the "label" output is fixed, would be good to append
-                    # the "dataset_name" to it as we do in the API put. Might be worth
-                    # just dropping XNAT outputs and just using API
-                    "label": path2label(output.name),
-                    "format": output.datatype.mime_like,
-                }
-            )
-            cmd_args.append(f"--output {output.name} '{output.name}'")
+            if self.internal_upload:
+                cmd_json["outputs"].append(
+                    {
+                        "name": output.name,
+                        "description": desc,
+                        "required": True,
+                        "mount": "out",
+                        "path": out_fname,
+                        "glob": None,
+                    }
+                )
+                cmd_json["xnat"][0]["output-handlers"].append(
+                    {
+                        "name": f"{output.name}-resource",
+                        "accepts-command-output": output.name,
+                        "via-wrapup-command": None,
+                        "as-a-child-of": "SESSION",
+                        "type": "Resource",
+                        # Shame that the "label" output is fixed, would be good to append
+                        # the "dataset_name" to it as we do in the API put. Might be worth
+                        # just dropping XNAT outputs and just using API
+                        "label": path2label(output.name),
+                        "format": output.datatype.mime_like,
+                    }
+                )
+                cmd_args.append(f"--output {output.name} '{output.name}'")
+            else:
+                replacement_key = f"[{output.field.upper()}_OUTPUT]"
+                cmd_json["inputs"].append(
+                    {
+                        "name": output.name,
+                        "description": desc,
+                        "type": self.COMMAND_INPUT_TYPES.get(output.datatype, "string"),
+                        "default-value": output.name,
+                        "required": False,
+                        "user-settable": True,
+                        "replacement-key": replacement_key,
+                    }
+                )
+                cmd_args.append(f"--output {output.name} '{replacement_key}'")
 
         return cmd_args
 
-    def add_pipeline2app_flags_field(self, cmd_json):
+    def add_pipeline2app_flags_field(self, cmd_json: ty.Dict[str, ty.Any]) -> str:
 
         # Add input for dataset name
         FLAGS_KEY = "#PIPELINE2APP_FLAGS#"
@@ -231,7 +252,7 @@ class XnatCommand(ContainerCommand):
 
         return FLAGS_KEY
 
-    def add_inputs_from_xnat(self, cmd_json):
+    def add_inputs_from_xnat(self, cmd_json: ty.Dict[str, ty.Any]) -> ty.List[str]:
 
         # Define the fixed subject>session dataset hierarchy of XNAT, i.e. the data
         # tree contains two levels, one for subjects and the other for sessions
@@ -340,7 +361,7 @@ class XnatCommand(ContainerCommand):
         return cmd_args
 
     @classmethod
-    def path2xnatname(cls, path):
+    def path2xnatname(cls, path: str) -> str:
         return re.sub(r"[^a-zA-Z0-9_]+", "_", path)
 
     COMMAND_INPUT_TYPES = {bool: "bool", str: "string", int: "number", float: "number"}

--- a/pipeline2app/xnat/command.py
+++ b/pipeline2app/xnat/command.py
@@ -5,7 +5,9 @@ import attrs
 from fileformats.core import FileSet, to_mime
 from pipeline2app.core.command.base import ContainerCommand
 from frametree.xnat import XnatViaCS
+from frametree.xnat.api import path2label
 from frametree.common import Clinical
+
 
 if ty.TYPE_CHECKING:
     from .image import XnatApp
@@ -197,7 +199,7 @@ class XnatCommand(ContainerCommand):
                     # Shame that the "label" output is fixed, would be good to append
                     # the "dataset_name" to it as we do in the API put. Might be worth
                     # just dropping XNAT outputs and just using API
-                    "label": output.name,
+                    "label": path2label(output.name),
                     "format": output.datatype.mime_like,
                 }
             )

--- a/pipeline2app/xnat/deploy.py
+++ b/pipeline2app/xnat/deploy.py
@@ -3,13 +3,13 @@ import time
 import logging
 import json
 import xnat
-from pipeline2app.core.exceptions import Pydra2AppError
+from pipeline2app.core.exceptions import Pipeline2appError
 from pipeline2app.core.utils import extract_file_from_docker_image
 
 
 logger = logging.getLogger("pipeline2app-xnat")
 
-INTERNAL_INPUTS = ("Pydra2App_flags", "PROJECT_ID", "SUBJECT_LABEL", "SESSION_LABEL")
+INTERNAL_INPUTS = ("Pipeline2app_flags", "PROJECT_ID", "SUBJECT_LABEL", "SESSION_LABEL")
 
 
 def install_cs_command(
@@ -164,7 +164,7 @@ def launch_cs_command(
     unexpected_inputs = list(set(provided_inputs) - set(input_names))
     if missing_inputs or unexpected_inputs:
         raise ValueError(
-            f"Error launching '{cmd_name}' command:\n"
+            f"Error launching '{cmd_name}' command:\n"  # noqa
             f"    Valid inputs: {input_names}\n"
             f"    Provided inputs: {provided_inputs}\n"
             f"    Missing required inputs: {missing_inputs}\n"
@@ -179,7 +179,7 @@ def launch_cs_command(
     ).json()
 
     if launch_result["status"] != "success":
-        raise Pydra2AppError(
+        raise Pipeline2appError(
             f"{cmd_name} workflow wasn't launched successfully ({launch_result['status']})"
         )
     workflow_id = launch_result["workflow-id"]
@@ -210,13 +210,13 @@ def launch_cs_command(
         f"/xapi/containers/{container_id}/logs/stdout", accepted_status=[200, 204]
     )
     if stdout_result.status_code == 200:
-        out_str = f"stdout:\n{stdout_result.content.decode('utf-8')}\n"
+        out_str = f"stdout:\n{stdout_result.content.decode('utf-8')}\n"  # noqa
 
     stderr_result = xlogin.get(
         f"/xapi/containers/{container_id}/logs/stderr", accepted_status=[200, 204]
     )
     if stderr_result.status_code == 200:
-        out_str += f"\nstderr:\n{stderr_result.content.decode('utf-8')}"
+        out_str += f"\nstderr:\n{stderr_result.content.decode('utf-8')}"  # noqa
 
     if i == num_attempts - 1:
         status = f"NotCompletedAfter{max_runtime}Seconds"

--- a/pipeline2app/xnat/deploy.py
+++ b/pipeline2app/xnat/deploy.py
@@ -18,7 +18,7 @@ def install_cs_command(
     enable: bool = False,
     projects_to_enable: ty.Sequence[str] = (),
     replace_existing: bool = False,
-):
+) -> None:
     """Installs a new command for the XNAT container service and lanches it on
     the specified session.
 
@@ -92,7 +92,7 @@ def launch_cs_command(
     xlogin: xnat.XNATSession,
     timeout: int = 1000,  # seconds
     poll_interval: int = 10,  # seconds
-):
+) -> ty.Tuple[int, str, str]:
     """Installs a new command for the XNAT container service and lanches it on
     the specified session.
 
@@ -227,13 +227,13 @@ def launch_cs_command(
 
 
 def install_and_launch_xnat_cs_command(
-    command_json: dict,
+    command_json: ty.Dict[str, ty.Any],
     project_id: str,
     session_id: str,
     inputs: ty.Dict[str, str],
     xlogin: xnat.XNATSession,
-    **kwargs,
-):
+    **kwargs: ty.Any,
+) -> ty.Tuple[int, str, str]:
     """Installs a new command for the XNAT container service and lanches it on
     the specified session.
 

--- a/pipeline2app/xnat/deploy.py
+++ b/pipeline2app/xnat/deploy.py
@@ -284,6 +284,7 @@ INCOMPLETE_CS_STATES = (
     "Pending",
     "Running",
     "_Queued",
+    "Queued",
     "Staging",
     "Finalizing",
     "Created",

--- a/pipeline2app/xnat/image.py
+++ b/pipeline2app/xnat/image.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import json
+import typing as ty
 import attrs
 from neurodocker.reproenv import DockerRenderer
 from frametree.xnat import XnatViaCS
@@ -12,7 +13,7 @@ from .command import XnatCommand
 
 
 @attrs.define(kw_only=True)
-class XnatApp(App):
+class XnatApp(App):  # type: ignore[misc]
 
     PIP_DEPENDENCIES = (
         "pipeline2app-xnat",
@@ -21,7 +22,7 @@ class XnatApp(App):
     )
 
     command: XnatCommand = attrs.field(
-        converter=ObjectConverter(
+        converter=ObjectConverter(  # type: ignore[misc]
             XnatCommand
         )  # Change the command type to XnatCommand subclass
     )
@@ -30,8 +31,8 @@ class XnatApp(App):
         self,
         build_dir: Path,
         for_localhost: bool = False,
-        **kwargs,
-    ):
+        **kwargs: ty.Any,
+    ) -> DockerRenderer:
         """Creates a Docker image containing one or more XNAT commands ready
         to be installed in XNAT's container service plugin
 
@@ -74,10 +75,15 @@ class XnatApp(App):
 
         return dockerfile
 
-    def add_entrypoint(self, dockerfile: DockerRenderer, build_dir: Path):
+    def add_entrypoint(self, dockerfile: DockerRenderer, build_dir: Path) -> None:
         pass  # Don't need to add entrypoint as the command line is specified in the command JSON
 
-    def copy_command_ref(self, dockerfile: DockerRenderer, xnat_command, build_dir):
+    def copy_command_ref(
+        self,
+        dockerfile: DockerRenderer,
+        xnat_command: ty.Dict[str, ty.Any],
+        build_dir: Path,
+    ) -> None:
         """Copy the generated command JSON within the Docker image for future reference
 
         Parameters
@@ -97,8 +103,8 @@ class XnatApp(App):
         )
 
     def save_store_config(
-        self, dockerfile: DockerRenderer, build_dir: Path, for_localhost=False
-    ):
+        self, dockerfile: DockerRenderer, build_dir: Path, for_localhost: bool = False
+    ) -> None:
         """Save a configuration for a XnatViaCS store.
 
         Parameters

--- a/pipeline2app/xnat/tests/test_app.py
+++ b/pipeline2app/xnat/tests/test_app.py
@@ -57,12 +57,14 @@ def run_spec(
             "packages": {
                 "system": ["git", "vim"],
                 "pip": [
-                    "pipeline2app",
-                    "pipeline2app-xnat",
                     "fileformats",
+                    "fileformats-extras",
                     "fileformats-medimage",
+                    "fileformats-medimage-extras",
                     "frametree",
                     "frametree-xnat",
+                    "pipeline2app",
+                    "pipeline2app-xnat",
                     "pydra",
                 ],
             },
@@ -95,10 +97,11 @@ def run_spec(
                 "system": ["git", "vim"],
                 "pip": [
                     "fileformats",
+                    "fileformats-extras",
                     "fileformats-medimage",
                     "fileformats-medimage-extras",
-                    "frametree-bids",
                     "frametree",
+                    "frametree-bids",
                     "frametree-xnat",
                     "pydra",
                     "pipeline2app",
@@ -252,7 +255,12 @@ def test_xnat_cs_pipeline(xnat_repository, run_spec, run_prefix, work_dir):
 
         for output_name, sinked_name in output_values.items():
             deriv = next(d for d in blueprint.derivatives if d.path == output_name)
-            assert sorted(
+            uploaded_files = sorted(
                 Path(f).name.lstrip("sub-DEFAULT_")
                 for f in test_xsession.resources[sinked_name].files
-            ) == sorted(deriv.filenames)
+            )
+            if image_spec.command.internal_upload:
+                reference = sorted(d.rstrip("_sink") + ".txt" for d in deriv.filenames)
+            else:
+                reference = sorted(deriv.filenames)
+            assert uploaded_files == reference

--- a/pipeline2app/xnat/tests/test_app.py
+++ b/pipeline2app/xnat/tests/test_app.py
@@ -37,7 +37,7 @@ def run_spec(
             "version": {
                 "package": "1.0",
             },
-            "title": "A pipeline to test Pydra2App's deployment tool",
+            "title": "A pipeline to test Pipeline2app's deployment tool",
             "command": command_spec,
             "authors": [{"name": "Some One", "email": "some.one@an.email.org"}],
             "docs": {

--- a/pipeline2app/xnat/tests/test_app.py
+++ b/pipeline2app/xnat/tests/test_app.py
@@ -13,12 +13,17 @@ from pipeline2app.xnat.deploy import (
     install_and_launch_xnat_cs_command,
 )
 from fileformats.medimage import NiftiGzX, NiftiGzXBvec
+from fileformats.text import Plain as Text
+from frametree.common import Clinical
 
 
 PIPELINE_NAME = "test-concatenate"
 
 
-@pytest.fixture(params=["func", "bids_app"], scope="session")
+@pytest.fixture(
+    params=["func_api", "bidsapp_api", "func_internal", "bidsapp_internal"],
+    scope="session",
+)
 def run_spec(
     command_spec,
     bids_command_spec,
@@ -30,10 +35,14 @@ def run_spec(
     run_prefix,
 ):
     spec = {}
-    if request.param == "func":
+    task, upload_method = request.param.split("_")
+    run_prefix += upload_method
+    access_method = "cs" + ("_internal" if upload_method == "internal" else "")
+    if task == "func":
+        cmd_spec = command_spec
         spec["build"] = {
             "org": "pipeline2app-tests",
-            "name": "concatenate-xnat-cs",
+            "name": run_prefix + "-concatenate-xnat-cs",
             "version": {
                 "package": "1.0",
             },
@@ -52,6 +61,8 @@ def run_spec(
                     "pipeline2app-xnat",
                     "fileformats",
                     "fileformats-medimage",
+                    "frametree",
+                    "frametree-xnat",
                     "pydra",
                 ],
             },
@@ -63,14 +74,15 @@ def run_spec(
             dataset_id=project_id,
         )
         spec["dataset"] = access_dataset(
-            project_id, "cs", xnat_repository, xnat_archive_dir
+            project_id, access_method, xnat_repository, xnat_archive_dir, run_prefix
         )
         spec["params"] = {"number_of_duplicates": 2}
-    elif request.param == "bids_app":
+    elif task == "bidsapp":
         bids_command_spec["configuration"]["executable"] = "/launch.sh"
+        cmd_spec = bids_command_spec
         spec["build"] = {
             "org": "pipeline2app-tests",
-            "name": "bids-app-xnat-cs",
+            "name": run_prefix + "-bids-app-xnat-cs",
             "version": {
                 "package": "1.0",
             },
@@ -86,6 +98,7 @@ def run_spec(
                     "fileformats-medimage",
                     "fileformats-medimage-extras",
                     "frametree-bids",
+                    "frametree",
                     "frametree-xnat",
                     "pydra",
                     "pipeline2app",
@@ -141,19 +154,34 @@ def run_spec(
                     ],
                 ),
             ],
+            derivatives=[
+                FileBP(
+                    path="file1",
+                    row_frequency=Clinical.session,
+                    datatype=Text,
+                    filenames=["file1.txt"],
+                ),
+                FileBP(
+                    path="file2",
+                    row_frequency=Clinical.session,
+                    datatype=Text,
+                    filenames=["file2.txt"],
+                ),
+            ],
         )
-        project_id = run_prefix + "xnat_cs_bids_app"
+        project_id = run_prefix + "xnat_cs_bidsapp"
         blueprint.make_dataset(
             store=xnat_repository,
             dataset_id=project_id,
             source_data=nifti_sample_dir,
         )
         spec["dataset"] = access_dataset(
-            project_id, "cs", xnat_repository, xnat_archive_dir
+            project_id, access_method, xnat_repository, xnat_archive_dir, run_prefix
         )
         spec["params"] = {}
     else:
-        assert False, f"unrecognised request param '{request.param}'"
+        assert False, f"unrecognised request param '{task}'"
+    cmd_spec["internal_upload"] = upload_method == "internal"
     return spec
 
 
@@ -166,9 +194,6 @@ def test_xnat_cs_pipeline(xnat_repository, run_spec, run_prefix, work_dir):
     dataset = run_spec["dataset"]
     params = run_spec["params"]
     blueprint = dataset.__annotations__["blueprint"]
-
-    # Append run_prefix to command name to avoid clash with previous test runs
-    build_spec["name"] = "xnat-cs-test" + run_prefix
 
     image_spec = XnatApp(**build_spec)
 
@@ -194,6 +219,13 @@ def test_xnat_cs_pipeline(xnat_repository, run_spec, run_prefix, work_dir):
     for pname, pval in params.items():
         launch_inputs[pname] = pval
 
+    if image_spec.command.internal_upload:
+        # If using internal upload, the output names are fixed
+        output_values = {o: o for o in image_spec.command.output_names}
+    else:
+        output_values = {o: o + "_sink" for o in image_spec.command.output_names}
+        launch_inputs.update(output_values)
+
     with xnat_repository.connection:
 
         xlogin = xnat_repository.connection
@@ -210,11 +242,17 @@ def test_xnat_cs_pipeline(xnat_repository, run_spec, run_prefix, work_dir):
 
         assert status == "Complete", f"Workflow {workflow_id} failed.\n{out_str}"
 
+        access_type = "direct" if image_spec.command.internal_upload else "api"
+
+        assert f"via {access_type} access" in out_str.lower()
+
         assert sorted(r.label for r in test_xsession.resources.values()) == sorted(
-            deriv.path for deriv in blueprint.derivatives
+            output_values.values()
         )
 
-        for deriv in blueprint.derivatives:
-            assert [
-                Path(f).name for f in test_xsession.resources[deriv.path].files
-            ] == deriv.filenames
+        for output_name, sinked_name in output_values.items():
+            deriv = next(d for d in blueprint.derivatives if d.path == output_name)
+            assert sorted(
+                Path(f).name.lstrip("sub-DEFAULT_")
+                for f in test_xsession.resources[sinked_name].files
+            ) == sorted(deriv.filenames)

--- a/pipeline2app/xnat/tests/test_app.py
+++ b/pipeline2app/xnat/tests/test_app.py
@@ -65,7 +65,7 @@ def run_spec(
         spec["dataset"] = access_dataset(
             project_id, "cs", xnat_repository, xnat_archive_dir
         )
-        spec["params"] = {"duplicates": 2}
+        spec["params"] = {"number_of_duplicates": 2}
     elif request.param == "bids_app":
         bids_command_spec["configuration"]["executable"] = "/launch.sh"
         spec["build"] = {
@@ -209,6 +209,10 @@ def test_xnat_cs_pipeline(xnat_repository, run_spec, run_prefix, work_dir):
         )
 
         assert status == "Complete", f"Workflow {workflow_id} failed.\n{out_str}"
+
+        assert sorted(r.label for r in test_xsession.resources.values()) == sorted(
+            deriv.path for deriv in blueprint.derivatives
+        )
 
         for deriv in blueprint.derivatives:
             assert [

--- a/pipeline2app/xnat/tests/test_app.py
+++ b/pipeline2app/xnat/tests/test_app.py
@@ -159,13 +159,13 @@ def run_spec(
                     path="file1",
                     row_frequency=Clinical.session,
                     datatype=Text,
-                    filenames=["file1.txt"],
+                    filenames=["file1_sink.txt"],
                 ),
                 FileBP(
                     path="file2",
                     row_frequency=Clinical.session,
                     datatype=Text,
-                    filenames=["file2.txt"],
+                    filenames=["file2_sink.txt"],
                 ),
             ],
         )

--- a/pipeline2app/xnat/tests/test_command.py
+++ b/pipeline2app/xnat/tests/test_command.py
@@ -6,7 +6,7 @@ from pipeline2app.core import ContainerCommand
 from conftest import TEST_XNAT_DATASET_BLUEPRINTS, access_dataset
 
 
-@pytest.mark.parametrize("access_method", ["api", "cs"])
+@pytest.mark.parametrize("access_method", ["api", "cs", "cs-internal"])
 def test_command_execute(
     xnat_repository, command_spec, work_dir, run_prefix, access_method, xnat_archive_dir
 ):
@@ -41,7 +41,7 @@ def test_command_execute(
             ("second_file", "scan2"),
         ],
         output_values=[
-            ("sink_file", "concatenated_file"),
+            ("concatenated_file", "sink_file"),
         ],
         parameter_values=[
             ("number_of_duplicates", str(duplicates)),
@@ -54,7 +54,7 @@ def test_command_execute(
         pipeline_name="test_pipeline",
     )
     # Add source column to saved dataset
-    reloaded = dataset.store.load_frameset(dataset.id, name=dataset.name)
+    reloaded = dataset.reload()
     sink = reloaded["sink_file"]
     assert len(sink) == reduce(mul, bp.dim_lengths)
     fnames = ["file1.txt", "file2.txt"]

--- a/pipeline2app/xnat/tests/test_command.py
+++ b/pipeline2app/xnat/tests/test_command.py
@@ -1,0 +1,65 @@
+from operator import mul
+from functools import reduce
+import random
+import pytest
+from pipeline2app.core import ContainerCommand
+from conftest import TEST_XNAT_DATASET_BLUEPRINTS, access_dataset
+
+
+@pytest.mark.parametrize("access_method", ["api", "cs"])
+def test_command_execute(
+    xnat_repository, command_spec, work_dir, run_prefix, access_method, xnat_archive_dir
+):
+    # Get CLI name for dataset (i.e. file system path prepended by 'file_system//')
+
+    duplicates = 1
+    bp = TEST_XNAT_DATASET_BLUEPRINTS["concatenate_test"]
+    project_id = (
+        run_prefix
+        + "contenatecommand"
+        + access_method
+        + str(hex(random.getrandbits(16)))[2:]
+    )
+    bp.make_dataset(
+        dataset_id=project_id,
+        store=xnat_repository,
+        name="",
+    )
+    dataset = access_dataset(
+        project_id, access_method, xnat_repository, xnat_archive_dir, run_prefix
+    )
+    dataset.save()
+
+    command = ContainerCommand(**command_spec)
+
+    # Start generating the arguments for the CLI
+    # Add source to loaded dataset
+    command.execute(
+        address=dataset.locator,
+        input_values=[
+            ("first_file", "scan1"),
+            ("second_file", "scan2"),
+        ],
+        output_values=[
+            ("sink_file", "concatenated_file"),
+        ],
+        parameter_values=[
+            ("number_of_duplicates", str(duplicates)),
+        ],
+        raise_errors=True,
+        plugin="serial",
+        work_dir=str(work_dir),
+        loglevel="debug",
+        dataset_hierarchy=",".join(bp.hierarchy),
+        pipeline_name="test_pipeline",
+    )
+    # Add source column to saved dataset
+    reloaded = dataset.store.load_frameset(dataset.id, name=dataset.name)
+    sink = reloaded["sink_file"]
+    assert len(sink) == reduce(mul, bp.dim_lengths)
+    fnames = ["file1.txt", "file2.txt"]
+    expected_contents = "\n".join(fnames * duplicates)
+    for item in sink:
+        with open(item) as f:
+            contents = f.read()
+        assert contents == expected_contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,12 @@ per-file-ignores = ["__init__.py:F401"]
 max-line-length = 88
 select = "C,E,F,W,B,B950"
 extend-ignore = ['E203', 'E501', 'E129', 'W503']
+
+
+[tool.mypy]
+python_version = "3.8"
+ignore_missing_imports = true
+strict = true
+namespace_packages = true
+explicit_package_bases = true
+exclude = ["tests", "scripts", "docs", "build", "dist"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ doc = [
 ]
 test = [
     "frametree-bids >=0.1",
-    "fileformats-testing",
     "medimages4tests >=0.3",
     "pytest >=5.4.3",
     "pytest-cov >=2.12.1",


### PR DESCRIPTION
* Switch to use API upload from CS pipelines by default
* XNAT output uploader can be specified by setting the "internal_upload" boolean attribute of the XnatCommand